### PR TITLE
Add support for upcoming source_provider plugin hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Cocoapods::repo-svn changelog
 
+# Master
+
+* Add support for new source provider plugin hook (CocoaPods [#3792](https://github.com/CocoaPods/CocoaPods/pull/3792))
+
 ## 0.1.1
 
 * Migrating to new CLAide::Arguments (CocoaPods/CLAide#33)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Our team had been using a in house fork of Cocoapods with svn, bzr, and hg spec-
 
     $ gem install cocoapods-repo-svn 
 
-## Usage
+# Usage
+
+## Commands
 
 Add
 
@@ -26,6 +28,15 @@ Update
 Remove
 
     $ pod repo-svn remove my-svn-repo 
+
+## Podfile integration
+
+To include your sources in the install phase of your project, do the following:
+```ruby
+plugin 'cocoapods-repo-svn', :sources => [
+        'https://svn.myrepository.com'
+    ]
+```
 
     
 ## Contributing

--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -1,1 +1,54 @@
 require 'pod/command/repo_svn'
+require 'svn_source'
+
+# This pre_install hook requires cocoapods v. 0.38.0.beta.2 or higher
+Pod::HooksManager.register('cocoapods-repo-svn', :source_provider) do |context, options|
+    Pod::UI.message 'cocoapods-repo-svn received source_provider hook'
+    return unless sources = options['sources']
+    sources.each do |url|
+        source = create_source_with_url(url)
+        update_or_add_source(source)
+        context.add_source(source)
+    end
+end
+
+# @param [Source] source The source to add or update
+#
+# @return [Void]
+#
+def update_or_add_source(source)
+    name = source.name
+    url = source.url
+    dir = source.repo
+
+    if dir.exist?
+        argv = CLAide::ARGV.new([name])
+        cmd = Pod::Command::RepoSvn::Update.new(argv)
+    else
+        argv = CLAide::ARGV.new([name, url])
+        cmd = Pod::Command::RepoSvn::Add.new(argv)
+    end
+
+    cmd.run() 
+end
+
+# @param [String] url The URL of the SVN repository
+#
+# @return [String] a name for the repository
+#
+# For now, this uses the last component of the URL as the name
+# So https://my.server.com/somedir/Specs will return Specs
+def name_for_url(url)
+    return nil unless url
+    delim = '/'
+    components = url.split(delim)
+    components.last
+end
+
+
+def create_source_with_url(url)
+    name = name_for_url(url)
+    repos_dir = Pod::Config.instance.repos_dir
+    repo = repos_dir + name
+    Pod::SvnSource.new(repo,url)
+end

--- a/lib/pod/command/repo_svn.rb
+++ b/lib/pod/command/repo_svn.rb
@@ -37,7 +37,8 @@ module Pod
             config.repos_dir.mkpath
             Dir.chdir(config.repos_dir) do
               command = "checkout --non-interactive --trust-server-cert '#{@url}' #{@name}"
-              !svn(command)
+              #!svn(command)
+              `svn #{command}`
             end
             SourcesManager.check_version_information(dir) #todo: TEST ME
           end
@@ -103,7 +104,8 @@ module Pod
             UI.section "Updating spec repo `#{source.name}`" do
               Dir.chdir(source.repo) do
                 begin
-                  output = svn!('up --non-interactive --trust-server-cert')
+                  #output = svn('up --non-interactive --trust-server-cert')
+                  output = `svn up --non-interactive --trust-server-cert`
                   UI.puts output if show_output && !config.verbose?
                 rescue Informative => e
                   UI.warn 'CocoaPods was not able to update the ' \
@@ -150,7 +152,7 @@ module Pod
         # @return [Bool] Whether the given source is a SVN repo.
         #
         def svn_repo?(dir)
-          Dir.chdir(dir) { svn('info  >/dev/null 2>&1') }
+          Dir.chdir(dir) { `svn info > /dev/null` }
           $?.success?
         end
       end

--- a/lib/svn_source.rb
+++ b/lib/svn_source.rb
@@ -1,0 +1,18 @@
+module Pod
+  # Subclass of Pod::Source to provide support for SVN Specs repositories
+  #
+  class SvnSource < Source
+    # @return [String] The remote URL of the repository
+    #
+    attr_accessor :url
+
+    # @param [String] repo The name of the repository (aka. directory name)
+    #
+    # @param [String] url see {#url}
+    #
+    def initialize(repo, url)
+      super(repo)
+      @url = url
+    end
+  end
+end


### PR DESCRIPTION
Here's an initial implementation that supports the yet-to-be-completed plugin source_provider hook as described in CocoaPods/CocoaPods#3792

Some tests should probably be made for the new functionality, but for now I have successfully tested it on my machine using my branch of cocoapods that includes the new plugin hook.

Example:
```ruby
plugin 'cocoapods-repo-svn', {
    :sources => [
        "https://svn.myrepo.com/private-specs"
    ]
}
```

```bash
$ pod install
Updating spec repo `private-specs`
Updating '.':
At revision 12345.
Analyzing dependencies
Downloading dependencies
...
```

About the SVN executable & backticks.. I kept getting errors such as "Unknown subcommand: 'up --non-interactive --trust-server-cert'" from svn when using the `svn!('up --non-interactive --trust-server-cert')` syntax.

Let me know what you think!