### PR TITLE
Fix to 'repo-svn push' command

### DIFF
--- a/lib/pod/command/repo_svn.rb
+++ b/lib/pod/command/repo_svn.rb
@@ -350,7 +350,7 @@ module Pod
               Dir.chdir(repo_dir) do
                 # only commit if modified
                 UI.puts "Committing changes"
-                UI.puts `svn add #{spec.name} 2> /dev/null`
+                UI.puts `svn add #{spec.name} --force 2> /dev/null`
                 UI.puts `svn commit -m "#{message}"`
               end
             end


### PR DESCRIPTION
Trying to push an existing podspec with an increased version number
fails to update the repository.

Issue fails with:

svn: warning: W150002:
'/Users/user/.cocoapods/repos/PrivateRepo/MyProject’ is already under
version control

The solution is to add the —force command to the ‘svn add’ operation,
and the commit happens successfully.